### PR TITLE
added the ability to filter by dependencies object, not just devDependencies:

### DIFF
--- a/tasks/dev_update.js
+++ b/tasks/dev_update.js
@@ -1,6 +1,6 @@
 /*
  * grunt-dev-update
- * 
+ *
  *
  * Copyright (c) 2013 Gilad Peleg
  * Licensed under the MIT license.
@@ -10,30 +10,32 @@ var _ = require('lodash');
 
 'use strict';
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
 
-    var devUpdate = require('./lib/dev_update')(grunt);
+	var devUpdate = require('./lib/dev_update')(grunt);
 
-    grunt.registerMultiTask('devUpdate', 'See your outdated devDependencies and update them', function () {
+	grunt.registerMultiTask('devUpdate', 'See your outdated devDependencies and update them', function() {
 
-        //set default options
-        devUpdate.options = this.options({
-            updateType   : 'report',
-            reportUpdated: false
-        });
+		//set default options
+		devUpdate.options = this.options({
+			updateType: 'report',
+			reportUpdated: false,
+			packageType: 'default',
+			saveType: '--save'
+		});
 
-        var possibleUpdateTypes = ['report', 'force', 'prompt'];
-        grunt.verbose.writeflags(devUpdate.options, 'Options');
-        grunt.verbose.writelns('Using target: ' + this.target);
+		var possibleUpdateTypes = ['report', 'force', 'prompt'];
+		grunt.verbose.writeflags(devUpdate.options, 'Options');
+		grunt.verbose.writelns('Using target: ' + this.target);
 
-        //validate updateType option
-        if (!_.contains(possibleUpdateTypes, devUpdate.options.updateType)) {
-            grunt.fail.warn('updateType ' + String(devUpdate.options.updateType).cyan + ' not supported.');
-            //if force
-            devUpdate.options.updateType = 'report';
-        }
+		//validate updateType option
+		if (!_.contains(possibleUpdateTypes, devUpdate.options.updateType)) {
+			grunt.fail.warn('updateType ' + String(devUpdate.options.updateType).cyan + ' not supported.');
+			//if force
+			devUpdate.options.updateType = 'report';
+		}
 
-        //run task
-        devUpdate.runTask(this.async());
-    });
+		//run task
+		devUpdate.runTask(this.async());
+	});
 };

--- a/tasks/lib/dev_update.js
+++ b/tasks/lib/dev_update.js
@@ -7,238 +7,260 @@
  */
 
 var async = require('async'),
-    _ = require('lodash'),
-    inquirer = require("inquirer"),
-    path = require('path'),
-    ProgressBar = require('progress');
+	_ = require('lodash'),
+	inquirer = require("inquirer"),
+	path = require('path'),
+	ProgressBar = require('progress');
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
 
-    var exports = {
-        options: {},
-        devDeps: [],
-        results: {}
-    };
+	var exports = {
+		options: {},
+		deps: [],
+		results: {}
+	};
 
-    //default spawn options
-    exports.spawnOptions = {
-        cmd  : 'npm',
-        grunt: false,
-        opts : {}
-    };
+	//default spawn options
+	exports.spawnOptions = {
+		cmd: 'npm',
+		grunt: false,
+		opts: {}
+	};
 
-    exports.stats = {
-        outdated: 0,
-        upToDate: 0
-    };
+	exports.stats = {
+		outdated: 0,
+		upToDate: 0
+	};
 
-    /**
-     * Get the dev dependencies packages to update from package.json
-     */
-    exports.getDevPackages = function () {
-        //TODO add package.json route to options
-        var packagePath = path.join(process.cwd(), 'package.json');
-        grunt.verbose.writelns('Using path for package.json: ' + packagePath);
-        exports.devDeps = require('matchdep').filterDev('*', packagePath);
-        grunt.log.writeln('Found %s devDependencies to check for latest version', exports.devDeps.length);
-    };
+	/**
+	 * Get the dev dependencies packages to update from package.json
+	 */
+	exports.getPackages = function(packageType) {
+		//TODO add package.json route to options
+		var packagePath = path.join(process.cwd(), 'package.json'),
+			matchDep = require('matchdep'),
+			filterPackages = function() {};
+		grunt.verbose.writelns('Using path for package.json: ' + packagePath);
+		switch (packageType) {
+			case "dev":
+				filterPackages = matchDep.filterDev;
+				break;
+			case "default":
+			default:
+				filterPackages = matchDep.filter;
+				break;
+		}
+		exports.deps = filterPackages('*', require(packagePath));
+		grunt.log.writeln('Found %s %sDependencies to check for latest version', exports.deps.length, packageType);
+	};
 
-    exports.getSpawnArguments = function (devDep, phase) {
-        switch (phase) {
-            case 'local':
-                return ['list', devDep, '--json', '--depth=1'];
-                break;
+	exports.getSpawnArguments = function(dep, phase) {
+		switch (phase) {
+			case 'local':
+				return ['list', dep, '--json', '--depth=1'];
+				break;
 
-            case  'remote':
-                return ['view', devDep, 'version'];
-                break;
+			case 'remote':
+				return ['view', dep, 'version'];
+				break;
 
-            case 'update':
-                return ['install', devDep, '--save-dev'];
-                break;
-        }
-        return [];
-    };
+			case 'update':
+				grunt.verbose.writelns(exports.options.saveType);
+				return ['install', dep + '@' + exports.results[dep].remoteVersion, exports.options.saveType];
+				break;
+		}
+		return [];
+	};
 
-    /**
-     * @param {String[]} packages
-     * @param {Function} done callback function
-     */
-    exports.getLocalPackageVersion = function (packages, done) {
-        /** Fetching data phase **/
+	/**
+	 * @param {String[]} packages
+	 * @param {Function} done callback function
+	 */
+	exports.getLocalPackageVersion = function(packages, done) {
+		/** Fetching data phase **/
 
-        var bar = new ProgressBar('Getting local packages versions [:bar] :percent :etas', { total: packages.length });
+		var bar = new ProgressBar('Getting local packages versions [:bar] :percent :etas', {
+			total: packages.length
+		});
 
-        async.each(packages,
-            function (devDep, callback) {
-                //make current task arguments
+		async.each(packages,
+			function(dep, callback) {
+				//make current task arguments
 
-                bar.tick();
+				bar.tick();
 
-                exports.spawnOptions.args = exports.getSpawnArguments(devDep, 'local');
-                exports.results[devDep] = {};
+				exports.spawnOptions.args = exports.getSpawnArguments(dep, 'local');
+				exports.results[dep] = {};
+				grunt.util.spawn(exports.spawnOptions, function(error, result, code) {
+					if (error) {
+						grunt.verbose.writelns(error);
+						exports.results[dep].isError = true;
+						grunt.log.writelns('Error in getting local package version of ' + dep);
+						callback();
+						return;
+					}
 
-                grunt.util.spawn(exports.spawnOptions, function (error, result, code) {
-                    if (error) {
-                        grunt.verbose.writelns(error);
-                        exports.results[devDep].isError = true;
-                        grunt.log.writelns('Error in getting local package version of ' + devDep);
-                        callback();
-                        return;
-                    }
+					var localVersion;
+					//insert dep into taskObject as a key with localVersion
+					try {
+						localVersion = JSON.parse(result).dependencies[dep].version;
+					}
+					catch (e) {
+						grunt.verbose.writelns(e);
+						exports.results[dep].isError = true;
+						grunt.log.writelns('Error in JSON.parse of the local package info of ' + dep);
+						callback();
+						return;
+					}
 
-                    var localVersion;
-                    //insert devDep into taskObject as a key with localVersion
-                    try {
-                        localVersion = JSON.parse(result).dependencies[devDep].version;
-                    }
-                    catch (e) {
-                        grunt.verbose.writelns(e);
-                        exports.results[devDep].isError = true;
-                        grunt.log.writelns('Error in JSON.parse of the local package info of ' + devDep);
-                        callback();
-                        return;
-                    }
+					exports.results[dep] = {
+						localVersion: localVersion
+					};
 
-                    exports.results[devDep] = {
-                        localVersion: localVersion
-                    };
+					//success
+					grunt.verbose.writelns('Got local version for package %s -> %s', dep, exports.results[dep].localVersion);
+					callback();
+				});
+			}, done);
+	};
 
-                    //success
-                    grunt.verbose.writelns('Got local version for package %s -> %s', devDep, exports.results[devDep].localVersion);
-                    callback();
-                });
-            }, done);
-    };
+	/**
+	 * @param {String[]} packages
+	 * @param {Function} done callback function
+	 */
+	exports.getRemotePackageVersion = function(packages, done) {
 
-    /**
-     * @param {String[]} packages
-     * @param {Function} done callback function
-     */
-    exports.getRemotePackageVersion = function (packages, done) {
+		var bar = new ProgressBar('Getting remote packages versions [:bar] :percent :etas', {
+			total: packages.length
+		});
 
-        var bar = new ProgressBar('Getting remote packages versions [:bar] :percent :etas', { total: packages.length });
+		/** Fetching data phase **/
+		async.each(packages,
+			function(dep, callback) {
 
-        /** Fetching data phase **/
-        async.each(packages,
-            function (devDep, callback) {
+				bar.tick();
+				//make current task arguments
+				exports.spawnOptions.args = exports.getSpawnArguments(dep, 'remote');
 
-                bar.tick();
-                //make current task arguments
-                exports.spawnOptions.args = exports.getSpawnArguments(devDep, 'remote');
+				grunt.util.spawn(exports.spawnOptions, function(error, result, code) {
+					if (error) {
+						grunt.verbose.writelns(error);
+						exports.results[dep].isError = true;
+						grunt.log.writelns('Error in getting remote package version of ' + dep);
+						callback();
+						return;
+					}
+					grunt.verbose.writelns('Got remote version for package %s -> %s', dep, result.stdout);
+					exports.results[dep].remoteVersion = result.stdout;
 
-                grunt.util.spawn(exports.spawnOptions, function (error, result, code) {
-                    if (error) {
-                        grunt.verbose.writelns(error);
-                        exports.results[devDep].isError = true;
-                        grunt.log.writelns('Error in getting remote package version of ' + devDep);
-                        callback();
-                        return;
-                    }
-                    grunt.verbose.writelns('Got remote version for package %s -> %s', devDep, result.stdout);
-                    exports.results[devDep].remoteVersion = result.stdout;
+					//version is the same
+					if (result.stdout === exports.results[dep].localVersion) {
+						++exports.stats.upToDate;
+						var logMethod = exports.options.reportUpdated ? grunt.log.oklns : grunt.verbose.oklns;
+						logMethod('Package %s is at latest version %s', dep, result.stdout);
+						exports.results[dep].atLatest = true;
+					}
+					//version is outdated
+					else {
+						grunt.log.subhead('package %s is outdated.\nLocal version: %s, Latest version %s',
+							dep, exports.results[dep].localVersion, exports.results[dep].remoteVersion);
+						++exports.stats.outdated;
+					}
 
-                    //version is the same
-                    if (result.stdout === exports.results[devDep].localVersion) {
-                        ++exports.stats.upToDate;
-                        var logMethod = exports.options.reportUpdated ? grunt.log.oklns : grunt.verbose.oklns;
-                        logMethod('Package %s is at latest version %s', devDep, result.stdout);
-                        exports.results[devDep].atLatest = true;
-                    }
-                    //version is outdated
-                    else {
-                        grunt.log.subhead('package %s is outdated.\nLocal version: %s, Latest version %s',
-                            devDep, exports.results[devDep].localVersion, exports.results[devDep].remoteVersion);
-                        ++exports.stats.outdated;
-                    }
+					callback();
 
-                    callback();
+				});
+			}, done);
+	};
 
-                });
-            }, done);
-    };
+	/**
+	 * Process a package according to option updateType
+	 * @param {String[]} packages
+	 * @param {Function} done callback function
+	 */
+	exports.processByUpdateType = function(packages, done) {
+		/** Update phase **/
+		async.eachSeries(packages, function(dep, callback) {
+			var currentDep = exports.results[dep];
 
-    /**
-     * Process a package according to option updateType
-     * @param {String[]} packages
-     * @param {Function} done callback function
-     */
-    exports.processByUpdateType = function (packages, done) {
-        /** Update phase **/
-        async.eachSeries(packages, function (devDep, callback) {
-            var currentDep = exports.results[devDep];
+			if (currentDep.atLatest || currentDep.isError) {
+				callback();
+				return;
+			}
 
-            if (currentDep.atLatest || currentDep.isError) {
-                callback();
-                return;
-            }
+			if (exports.options.updateType === 'report') {
+				callback();
+			}
+			else if (exports.options.updateType === 'prompt') {
+				var msg = 'update using [npm install ' + dep + '@' + exports.results[dep].remoteVersion + ' ' + exports.options.saveType + ']';
+				inquirer.prompt({
+					name: 'confirm',
+					message: msg,
+					type: "confirm"
+				}, function(result) {
+					if (result.confirm) {
+						exports.updatePackage(dep, callback);
+						return;
+					}
+					callback();
+				});
+			}
+			else if (exports.options.updateType === 'force') {
+				exports.updatePackage(dep, callback);
+			}
+		}, done);
+	};
 
-            if (exports.options.updateType === 'report') {
-                callback();
-            }
-            else if (exports.options.updateType === 'prompt') {
-                var msg = 'update using [npm install ' + devDep + ' --save-dev]';
-                inquirer.prompt({ name: 'confirm', message: msg, type: "confirm" }, function (result) {
-                    if (result.confirm) {
-                        exports.updatePackage(devDep, callback);
-                        return;
-                    }
-                    callback();
-                });
-            }
-            else if (exports.options.updateType === 'force') {
-                exports.updatePackage(devDep, callback);
-            }
-        }, done);
-    };
+	/**
+	 * Update a package using npm install %package% %saveType%
+	 * @param {String} dep
+	 * @param {Function} done callback function
+	 */
+	exports.updatePackage = function(dep, done) {
+		exports.spawnOptions.args = exports.getSpawnArguments(dep, 'update');
+		exports.spawnOptions.opts = {
+			stdio: 'inherit'
+		};
+		grunt.util.spawn(exports.spawnOptions, function(error, result, code) {
+			if (error) {
+				grunt.verbose.writelns(error);
+				grunt.log.writelns('Error while updating package ' + dep);
+				done();
+				return;
+			}
 
-    /**
-     * Update a package using npm install %package% --save-dev
-     * @param {String} devDep
-     * @param {Function} done callback function
-     */
-    exports.updatePackage = function (devDep, done) {
-        exports.spawnOptions.args = exports.getSpawnArguments(devDep, 'update');
-        exports.spawnOptions.opts = {stdio: 'inherit'};
-        grunt.util.spawn(exports.spawnOptions, function (error, result, code) {
-            if (error) {
-                grunt.verbose.writelns(error);
-                grunt.log.writelns('Error while updating package ' + devDep);
-                done();
-                return;
-            }
+			grunt.log.oklns('Successfully updated package ' + dep);
+			done();
+		});
+	};
 
-            grunt.log.oklns('Successfully updated package ' + devDep);
-            done();
-        });
-    };
+	exports.runTask = function(done) {
+		async.series([
 
-    exports.runTask = function (done) {
-        async.series([
-            function (callback) {
-                //get the dev dependencies using matchdep
-                exports.getDevPackages();
-                //get local packages version
-                exports.getLocalPackageVersion(exports.devDeps, callback);
-            },
+			function(callback) {
+				//get the dev dependencies using matchdep
+				exports.getPackages(exports.options.packageType);
+				//get local packages version
+				exports.getLocalPackageVersion(exports.deps, callback);
+			},
 
-            function (callback) {
-                exports.getRemotePackageVersion(exports.devDeps, callback);
-            },
+			function(callback) {
+				exports.getRemotePackageVersion(exports.deps, callback);
+			},
 
-            function (callback) {
-                exports.processByUpdateType(exports.devDeps, callback);
-            }
+			function(callback) {
+				exports.processByUpdateType(exports.deps, callback);
+			}
 
-        ], function (err) {
-            if (err) {
-                grunt.log.error('Task failed due to error', err);
-            }
+		], function(err) {
+			if (err) {
+				grunt.log.error('Task failed due to error', err);
+			}
 
-            grunt.log.oklns('Found %s devDependencies. %s up-to-date, %s outdated', exports.devDeps.length, exports.stats.upToDate, exports.stats.outdated);
-            done();
-        });
-    };
+			grunt.log.oklns('Found %s dependencies. %s up-to-date, %s outdated', exports.deps.length, exports.stats.upToDate, exports.stats.outdated);
+			done();
+		});
+	};
 
-    return exports;
+	return exports;
 };


### PR DESCRIPTION
I found your grunt task useful for checking dependencies, but needed to check past just our devDependencies, so I extended the task to check for both ( and future considerations for more filters based on matchdep ). For now you can run devUpdate as:

``` javascript
devUpdate: {
            dev: {
                options: {
                    //should task report already updated dependencies
                    reportUpdated: false,
                    updateType: "force", // can be 'force'|'report'|'prompt'
                    packageType: 'dev', // dev|default **default is normal deps 
                    saveType: '--save-dev'
                }
            },
            main: {
                options: {
                    //should task report already updated dependencies
                    reportUpdated: false,
                    updateType: "prompt", // can be 'force'|'report'|'prompt'
                    packageType: 'default', // dev|default **default is normal deps 
                    saveType: '--save'
                }
            }
        }
```

to check either dev or main.

Commit log:
- fixed some formatting
- added defaults to the task runner
- added param for the checking either dev|default filter
- added param for the proper save indexes ( --save-dev|--save ) to package.json
- fixed installing of previous version if package.json is not updated before running 'npm install ...' command
