### PR TITLE
added option to save exact version of updated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ nearest package.json). This is the recommended and default option.
 
 For better understanding the `String` and `Object` option, please see [matchdep config](https://github.com/tkellen/node-matchdep#config).
 
+#### options.exact
+Type: `Boolean`
+Default value: `false`
+
+If `true`, will lock the version in your `package.json` at the latest version 
+found.  If `false`, it will default to NPM's behavior for `--save` and 
+`--save-dev`.
+
+```js
+// exact: false
+dependencies: {
+  "foo": "^1.2.3"
+}
+
+// exact: true
+dependencies: {
+  "foo": "1.2.3"
+}
+```
+
+
 ### Usage Examples
 
 #### Default Options
@@ -139,7 +160,8 @@ grunt.initConfig({
                     devDependencies: true, //only devDependencies
                     dependencies: false
                 },
-                packageJson: null //find package.json automatically
+                packageJson: null //find package.json automatically,
+                exact: false // do not save exact version
             }
         }
     }

--- a/tasks/dev_update.js
+++ b/tasks/dev_update.js
@@ -29,7 +29,9 @@ module.exports = function (grunt) {
                 dependencies: false
             },
             //by deafult - use matchdep default findup to locate package.json
-            packageJson: null
+            packageJson: null,
+            // default: when installing use the explicit version instead of "latest"
+            exact: false
         });
 
         grunt.verbose.writelns('Processing target: ' + this.target);

--- a/tasks/lib/dev_update.js
+++ b/tasks/lib/dev_update.js
@@ -65,8 +65,9 @@ module.exports = function (grunt) {
      * @param {String} dependency
      * @param {String} phase
      * @param {String} saveType should be either --save or --save-dev
+     * @param {String} version Latest version of dependency
      */
-    var getSpawnArguments = function (dependency, phase, saveType) {
+    var getSpawnArguments = function (dependency, phase, saveType, version) {
         switch (phase) {
         case 'outdated':
             return ['outdated', '--json', '--depth=0'];
@@ -74,8 +75,11 @@ module.exports = function (grunt) {
         case 'update':
             return ['update', dependency];
         case 'install':
+            // if using npm >= 1.4.5, the --save-exact and --save-dev-exact
+            // options are available, but this is backwards-compatible.
+            version = exports.options.exact ? version : 'latest';
             //this will force the version to install to override locks in package.json
-            return ['install', dependency + '@latest', saveType];
+            return ['install', dependency + '@' + version, saveType];
             //no action detected
         default:
             return [];
@@ -114,7 +118,7 @@ module.exports = function (grunt) {
             return done();
         }
         var updateType = exports.options.semver ? 'update' : 'install';
-        var spawnArgs = getSpawnArguments(pkg.name, updateType, pkg.installType);
+        var spawnArgs = getSpawnArguments(pkg.name, updateType, pkg.installType, specs.latest);
 
         //prompt user if package should be updated
         if (exports.options.updateType === 'prompt') {


### PR DESCRIPTION
- added option `exact` to save the exact version of a package, not `~<version>` or `^<version>` or whatever NPM wants to do.
- updated docs
