### PR TITLE
issue28: adding the saveType when running npm update

### DIFF
--- a/tasks/lib/dev_update.js
+++ b/tasks/lib/dev_update.js
@@ -38,7 +38,7 @@ var getSpawnArguments = function (phase, dependency, saveType) {
     case 'outdated':
         return ['outdated', '--json', '--depth=0'];
     case 'update':
-        return ['update', dependency];
+        return ['update', dependency, saveType];
     case 'install':
         //this will force the version to install to override locks in package.json
         return ['install', dependency + '@latest', saveType];


### PR DESCRIPTION
This intends to fix the issue [#28](https://github.com/pgilad/grunt-dev-update/issues/28)

By adding the saveType when updating an outdated local module, the package.json will my updated as well.

Example after applying the fix:
> Package name	: requirejs
> Package type	: devDependencies
> Current version	: 2.3.2
> Wanted version	: 2.3.3
> Latest version	: 2.3.3
> ? update using [npm update requirejs --save-dev]

