### PR TITLE
Adds reportonly check for package when updateType is set to fail

### DIFF
--- a/tasks/lib/dev_update.js
+++ b/tasks/lib/dev_update.js
@@ -147,17 +147,18 @@ module.exports = function (grunt) {
         grunt.log.writelns('Latest version\t:', specs.latest.red);
 
         var updateType = exports.options.updateType;
+        var onlyReportPkg = shouldOnlyReport(exports.options.reportOnlyPkgs, pkg.name);
         if (exports.options.semver && specs.current === specs.wanted) {
             grunt.log.ok('Package is up to date');
             return done();
         }
-        if (updateType === 'fail') {
+        if ((updateType === 'fail') && (!onlyReportPkg)) {
             grunt.warn('Found an outdated package: ' + String(pkg.name).underline + '.', 3);
         }
         if (updateType === 'report') {
             return done();
         }
-        if (shouldOnlyReport(exports.options.reportOnlyPkgs, pkg.name)) {
+        if (onlyReportPkg) {
             return done();
         }
         var spawnArgs = getSpawnArguments(


### PR DESCRIPTION
When I set updateType to fail and specify packages to only report, it still fails if one of the report only packages is out of date. This change allows it to fail if finds another package outdated, but only reports if the specified packages are outdated.

        options: {
          updateType: 'fail', // [report, prompt, force, fail]
          reportUpdated: false,
          semver: false, // stay within semver when updating
          packages: {
            devDependencies: false, // only check for devDependencies
            dependencies: true
          },
          packageJson: null, // use matchdep default findup to locate package.json
          reportOnlyPkgs: [
            'pkg1',
            'pkg2'
          ] // use updateType action on all packages
        }